### PR TITLE
refactor: merge base function name with its main function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Click on the link to open documentation of each package.
 Every commit should use this rule: https://www.conventionalcommits.org/en/v1.0.0-beta.4/
 This will affect CHANGELOG.md for each package when publishing and version increment.
 
-- "BREAKING CHANGES" will increase major version
+- "BREAKING CHANGE" will increase major version
 - "feat" will increase minor version
 - "fix" will increase patch version
 

--- a/examples/core/src/members/members-address/members-address.controller.ts
+++ b/examples/core/src/members/members-address/members-address.controller.ts
@@ -33,8 +33,8 @@ export class MembersAddressController extends BaseController<
 > {
   constructor(
     private readonly membersAddressService: MembersAddressService,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {
     super(
       membersAddressService,
@@ -50,14 +50,14 @@ export class MembersAddressController extends BaseController<
   async findAll(
     @Query() mainPagingDTO: MainPagingDTO,
   ): Promise<ResponseSuccessPaginationInterface> {
-    return this.baseFindAll(mainPagingDTO);
+    return this.findAll(mainPagingDTO);
   }
 
   @Get('/:id')
   @Permission('members.read')
   @AuthJwtGuard()
   async show(@Param('id') id: string): Promise<ResponseSuccessSingleInterface> {
-    return this.baseShow(id);
+    return this.show(id);
   }
 
   @Post()
@@ -66,7 +66,7 @@ export class MembersAddressController extends BaseController<
   async save(
     @Body() createDTO: CreateMembersAddressDTO,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseSave(createDTO);
+    return this.save(createDTO);
   }
 
   @Put('/:id')
@@ -76,7 +76,7 @@ export class MembersAddressController extends BaseController<
     @Param('id') id: string,
     @Body() updateDTO: UpdateMembersAddressDTO,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseUpdate(updateDTO, id);
+    return this.update(id, updateDTO);
   }
 
   @Delete('/:id')
@@ -85,6 +85,6 @@ export class MembersAddressController extends BaseController<
   async delete(
     @Param('id') id: string,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseDelete(id);
+    return this.delete(id);
   }
 }

--- a/examples/core/src/members/members-address/members-address.service.ts
+++ b/examples/core/src/members/members-address/members-address.service.ts
@@ -17,8 +17,8 @@ export class MembersAddressService extends BaseService<
   constructor(
     @InjectRepository(MemberAddressDocument)
     public memberAddressRepository: Repository<MemberAddressDocument>,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {
     super(
       memberAddressRepository,

--- a/examples/core/src/members/members.controller.ts
+++ b/examples/core/src/members/members.controller.ts
@@ -46,8 +46,8 @@ export class MembersController extends BaseController<
 > {
   constructor(
     private readonly membersService: MembersService,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {
     super(
       membersService,
@@ -78,14 +78,14 @@ export class MembersController extends BaseController<
   async myProfile(
     @User() user: IUser,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseShow(user.id);
+    return this.show(user.id);
   }
 
   @Get('/:id')
   @Permission('members.read')
   @AuthJwtGuard()
   async show(@Param('id') id: string): Promise<ResponseSuccessSingleInterface> {
-    return this.baseShow(id);
+    return this.show(id);
   }
 
   @Post()
@@ -94,7 +94,7 @@ export class MembersController extends BaseController<
   async save(
     @Body() createDTO: CreateMemberDTO,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseSave(createDTO);
+    return this.save(createDTO);
   }
 
   @Put('/:id')
@@ -104,7 +104,7 @@ export class MembersController extends BaseController<
     @Param('id') id: string,
     @Body() updateDTO: UpdateMemberDTO,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseUpdate(updateDTO, id);
+    return this.update(id, updateDTO);
   }
 
   @Delete('/:id')
@@ -113,7 +113,7 @@ export class MembersController extends BaseController<
   async delete(
     @Param('id') id: string,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseDelete(id);
+    return this.delete(id);
   }
 
   @Post('upload-photo')

--- a/examples/core/src/members/members.service.ts
+++ b/examples/core/src/members/members.service.ts
@@ -32,8 +32,8 @@ export class MembersService extends BaseService<
     @InjectRepository(MemberAddressDocument)
     public memberAddressRepository: Repository<MemberAddressDocument>,
     private readonly memberAddressService: MembersAddressService,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
     @InjectEntityManager() private entityManager: EntityManager,
     private readonly commonService: CommonService,
     private readonly fileStorageService: StorageServices,

--- a/examples/core/src/user-role/modules.service.ts
+++ b/examples/core/src/user-role/modules.service.ts
@@ -13,8 +13,8 @@ export class ModulesService extends BaseService<
   constructor(
     @InjectRepository(ModulePermissionsDocument)
     public repository: Repository<ModulePermissionsDocument>,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {
     super(repository, responseService, messageService, ModulesService.name);
     this.tableAlias = 'user_roles';

--- a/examples/core/src/user-role/user-roles.controller.ts
+++ b/examples/core/src/user-role/user-roles.controller.ts
@@ -35,8 +35,8 @@ export class UserRolesController extends BaseController<
   constructor(
     private readonly userRolesService: UserRolesService,
     private readonly modulesService: ModulesService,
-    private readonly messageService: MessageService,
-    private readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
   ) {
     super(
       userRolesService,

--- a/examples/core/src/user-role/user-roles.service.ts
+++ b/examples/core/src/user-role/user-roles.service.ts
@@ -36,8 +36,8 @@ export class UserRolesService extends BaseService<
     private readonly authPermissionService: AuthPermissionsService,
     @Inject(forwardRef(() => UsersService))
     private readonly usersService: UsersService,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {
     super(repository, responseService, messageService, UserRolesService.name);
 

--- a/examples/core/src/users/seeders/superadmin.seeder.ts
+++ b/examples/core/src/users/seeders/superadmin.seeder.ts
@@ -10,7 +10,7 @@ export class SuperAdminSeeder implements OnApplicationBootstrap {
   constructor(
     @InjectRepository(UserDocument)
     public userRepository: Repository<UserDocument>,
-    private readonly responseService: ResponseService,
+    protected readonly responseService: ResponseService,
   ) {}
   onApplicationBootstrap() {
     this.initSuperAdmins();

--- a/packages/nestjs-audit-trail/README.md
+++ b/packages/nestjs-audit-trail/README.md
@@ -124,8 +124,8 @@ for example:
 export class AuditTrailController {
   constructor(
     private readonly auditTrailService: AuditTrailService,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {}
 
   @Get()

--- a/packages/nestjs-audit-trail/libs/audit_trail/audit_trail.service.ts
+++ b/packages/nestjs-audit-trail/libs/audit_trail/audit_trail.service.ts
@@ -20,8 +20,8 @@ export class AuditTrailService extends MongoBaseService<
   constructor(
     @InjectModel(AuditTrail.name)
     private auditTrailRepository: Model<AuditTrailDocument>,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
     private readonly config: AitAuditTrailConfig,
   ) {
     super(

--- a/packages/nestjs-audit-trail/libs/base/abstract-base/service/mongo-service.base.ts
+++ b/packages/nestjs-audit-trail/libs/base/abstract-base/service/mongo-service.base.ts
@@ -135,10 +135,10 @@ export class MongoBaseService<
 
   protected constructor(
     // public repository: Repository<T>,
-    private repository: Model<T>,
-    private readonly baseResponseService: ResponseService,
-    private readonly baseMessageService: MessageService,
-    private readonly className: string,
+    protected repository: Model<T>,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
+    protected readonly className: string,
   ) {
     this.logger = new Logger(`${className}.${MongoBaseService.name}`);
   }
@@ -154,7 +154,7 @@ export class MongoBaseService<
       return this.repository.create(entitySave as T);
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -178,7 +178,7 @@ export class MongoBaseService<
       });
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -197,7 +197,7 @@ export class MongoBaseService<
       );
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -207,7 +207,7 @@ export class MongoBaseService<
    * @param filterQuery - The `filterQuery` parameter is an object of type  `BaseFilterGroup<PagingDTO>`. It represents a group of filter conditions that need to be applied to a query. The `BaseFilterGroup` type has the following structure:
    * @returns the "where" object, which contains the filter conditions based on the provided "mainPagingDTO" and "filterQuery".
    */
-  baseFilterAllQuery(
+  filterAllQuery(
     mainPagingDTO: PagingDTO,
     filterQuery: BaseFilterGroup<PagingDTO>,
   ) {
@@ -217,7 +217,7 @@ export class MongoBaseService<
     for (const condition of filterQuery.conditions) {
       let queryWhere;
       if (condition['logical_operator']) {
-        queryWhere = this.baseFilterAllQuery(
+        queryWhere = this.filterAllQuery(
           mainPagingDTO,
           condition as BaseFilterGroup<PagingDTO>,
         );
@@ -225,7 +225,7 @@ export class MongoBaseService<
           continue;
         }
       } else {
-        queryWhere = this.baseFilterQuery(
+        queryWhere = this.filterQuery(
           mainPagingDTO,
           condition as BaseFilterInterfaceSingle<PagingDTO>,
         );
@@ -251,7 +251,7 @@ export class MongoBaseService<
    * @returns the result of the `convertFilterToOperator` function if the condition
    * `!convertFilterToOperator(field, comparator, mainPagingDTO[key])` is truthy. Otherwise, it returns the result of the `convertFilterToOperator` function if the condition `mainPagingDTO[key]` is truthy.
    */
-  baseFilterQuery(
+  filterQuery(
     mainPagingDTO: PagingDTO,
     filterQuery: BaseFilterInterfaceSingle<PagingDTO>,
   ) {
@@ -269,16 +269,13 @@ export class MongoBaseService<
    * @param {PagingDTO} mainPagingDTO - PagingDTO object that contains information about pagination, sorting, and searching.
    * @returns an object with two properties: "where" and "sort".
    */
-  baseFindAllQuery(mainPagingDTO: PagingDTO): { where: any; sort: any } {
+  findAllQuery(mainPagingDTO: PagingDTO): { where: any; sort: any } {
     try {
       const where = {
         $and: [],
       };
 
-      const filter = this.baseFilterAllQuery(
-        mainPagingDTO,
-        this.filterByFields,
-      );
+      const filter = this.filterAllQuery(mainPagingDTO, this.filterByFields);
       if (filter) {
         where['$and'].push(filter);
       }
@@ -310,7 +307,7 @@ export class MongoBaseService<
       return { where, sort };
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -353,7 +350,7 @@ export class MongoBaseService<
       return roomListCount;
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -364,7 +361,7 @@ export class MongoBaseService<
    */
   async findAll(mainPagingDTO: PagingDTO): Promise<ListPaginationInterface<T>> {
     try {
-      const { where, sort } = this.baseFindAllQuery(mainPagingDTO);
+      const { where, sort } = this.findAllQuery(mainPagingDTO);
 
       const roomListCount = await this.exec(
         where,
@@ -383,7 +380,7 @@ export class MongoBaseService<
       };
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -396,10 +393,10 @@ export class MongoBaseService<
     try {
       if (!mongoose.Types.ObjectId.isValid(id)) {
         throw new BadRequestException(
-          this.baseResponseService.error(
+          this.responseService.error(
             HttpStatus.BAD_REQUEST,
             [
-              this.baseMessageService.getErrorMessage(
+              this.messageService.getErrorMessage(
                 `${this.tableAlias}_id`,
                 'general.general.data_invalid',
               ),
@@ -413,10 +410,10 @@ export class MongoBaseService<
         .exec();
       if (!recordT) {
         throw new BadRequestException(
-          this.baseResponseService.error(
+          this.responseService.error(
             HttpStatus.BAD_REQUEST,
             [
-              this.baseMessageService.getErrorMessage(
+              this.messageService.getErrorMessage(
                 `${this.tableAlias}_id`,
                 'general.general.id_not_found',
               ),
@@ -428,7 +425,7 @@ export class MongoBaseService<
       return recordT;
     } catch (error: any) {
       Logger.error(error.message, '', this.constructor.name);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 }

--- a/packages/nestjs-base/libs/abstract-base/controller/controller.base.ts
+++ b/packages/nestjs-base/libs/abstract-base/controller/controller.base.ts
@@ -35,15 +35,15 @@ export abstract class BaseController<
   public readonly logger;
 
   protected constructor(
-    private readonly baseService: BaseService<
+    private readonly service: BaseService<
       CreateDTO,
       UpdateDTO,
       EntityDocument,
       PagingDTO
     >,
-    private readonly baseResponseService: ResponseService,
-    private readonly baseMessageService: MessageService,
-    private readonly className: string,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
+    protected readonly className: string,
     protected readonly pagingClass: ClassConstructor<any> = MainPagingDTO,
   ) {
     this.logger = new Logger(className);
@@ -61,7 +61,11 @@ export abstract class BaseController<
     if (!(mainPagingDTO instanceof MainPagingDTO)) {
       mainPagingDTO = plainToClass(this.pagingClass, mainPagingDTO as any);
     }
-    return this.baseFindAll(mainPagingDTO);
+    const result = await this.service.findAll(mainPagingDTO);
+    return this.responseService.successCollection(
+      result.content,
+      result.pagination,
+    );
   }
 
   /**
@@ -71,7 +75,13 @@ export abstract class BaseController<
    */
   @Get('/:id')
   async show(@Param('id') id: string): Promise<ResponseSuccessSingleInterface> {
-    return this.baseShow(id);
+    const result: EntityDocument = await this.service.getDetailAndValidateById(
+      id,
+    );
+    return this.responseService.success(
+      result,
+      this.messageService.get('general.get.success'),
+    );
   }
 
   /**
@@ -84,7 +94,11 @@ export abstract class BaseController<
     @Body() createDTO: CreateDTO,
     user?: IUser,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseSave(createDTO);
+    const result: EntityDocument = await this.service.save(createDTO);
+    return this.responseService.success(
+      result,
+      this.messageService.get('general.create.success'),
+    );
   }
 
   /**
@@ -99,7 +113,11 @@ export abstract class BaseController<
     @Body() updateDTO: UpdateDTO,
     user?: IUser,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseUpdate(updateDTO, id);
+    const result: EntityDocument = await this.service.update(updateDTO, id);
+    return this.responseService.success(
+      result,
+      this.messageService.get('general.update.success'),
+    );
   }
 
   /**
@@ -111,113 +129,11 @@ export abstract class BaseController<
   async delete(
     @Param('id') id: string,
   ): Promise<ResponseSuccessSingleInterface> {
-    return this.baseDelete(id);
-  }
+    const result: DeleteResult = await this.service.delete(id);
 
-  /**
-   * This is an asynchronous function that returns a paginated collection of results obtained from a
-   * base service.
-   * @param {PagingDTO} mainPagingDTO - `mainPagingDTO` is an object that contains the parameters
-   * for pagination and filtering of data. It is likely used to retrieve a subset of data from a larger
-   * dataset, based on certain criteria such as page number, page size, sorting, and filtering. The
-   * `baseService` is likely a
-   * @returns a Promise that resolves to an object of type ResponseSuccessPaginationInterface. This
-   * object is created by calling the successCollection method of the baseResponseService object,
-   * passing in the content and pagination properties of the result object returned by calling the
-   * findAll method of the baseService object with the mainPagingDTO parameter.
-   */
-  async baseFindAll(
-    mainPagingDTO: PagingDTO,
-  ): Promise<ResponseSuccessPaginationInterface> {
-    const result = await this.baseService.findAll(mainPagingDTO);
-    return this.baseResponseService.successCollection(
-      result.content,
-      result.pagination,
-    );
-  }
-
-  /**
-   * This is an asynchronous function that retrieves a single entity document by ID and returns a
-   * success response with the retrieved data.
-   * @param {string} id - The `id` parameter is a string that represents the unique identifier of an
-   * entity that needs to be retrieved from the database. The `baseShow` function is an asynchronous
-   * function that takes in this `id` parameter and returns a Promise that resolves to a
-   * `ResponseSuccessSingleInterface` object. The
-   * @returns The function `baseShow` is returning a Promise that resolves to an object of type
-   * `ResponseSuccessSingleInterface`. This object contains the `result` obtained from calling the
-   * `getDetailAndValidateById` method of the `baseService`, and a success message obtained from the
-   * `baseMessageService`.
-   */
-  async baseShow(id: string): Promise<ResponseSuccessSingleInterface> {
-    const result: EntityDocument =
-      await this.baseService.getDetailAndValidateById(id);
-    return this.baseResponseService.success(
+    return this.responseService.success(
       result,
-      this.baseMessageService.get('general.get.success'),
-    );
-  }
-
-  /**
-   * This is an asynchronous function that saves a document entity and returns a success response with
-   * a message.
-   * @param {CreateDTO} createDTO - `createDTO` is an object that contains the data needed to create a
-   * new entity. It is likely defined as an interface or a class that specifies the required properties
-   * and their types. The `baseService.save()` method is called with this object as its argument to
-   * create a new entity in the database
-   * @returns The function `baseSave` is returning a Promise that resolves to an object of type
-   * `ResponseSuccessSingleInterface`. This object contains the result of calling the `save` method of
-   * the `baseService` with the `createDTO` parameter, and a success message obtained from the
-   * `baseMessageService`.
-   */
-  async baseSave(
-    createDTO: CreateDTO,
-  ): Promise<ResponseSuccessSingleInterface> {
-    const result: EntityDocument = await this.baseService.save(createDTO);
-    return this.baseResponseService.success(
-      result,
-      this.baseMessageService.get('general.create.success'),
-    );
-  }
-
-  /**
-   * This is an async function that updates an entity document and returns a success response with a
-   * message.
-   * @param {UpdateDTO} updateDTO - updateDTO is an object that contains the updated data for an
-   * entity. It is passed as an argument to the baseService.update() method, which updates the entity
-   * with the new data.
-   * @param {string} id - The `id` parameter is a string that represents the unique identifier of the
-   * entity that needs to be updated. It is used by the `baseService.update()` method to locate the
-   * entity in the database and update its properties based on the values provided in the `updateDTO`
-   * parameter.
-   * @returns A Promise that resolves to a ResponseSuccessSingleInterface object.
-   */
-  async baseUpdate(
-    updateDTO: UpdateDTO,
-    id: string,
-  ): Promise<ResponseSuccessSingleInterface> {
-    const result: EntityDocument = await this.baseService.update(updateDTO, id);
-    return this.baseResponseService.success(
-      result,
-      this.baseMessageService.get('general.update.success'),
-    );
-  }
-
-  /**
-   * This is an asynchronous function that deletes a record by ID and returns a success response with a
-   * message.
-   * @param {string} id - The `id` parameter is a string representing the unique identifier of the
-   * resource that needs to be deleted. It is used to identify the specific resource that needs to be
-   * deleted from the database.
-   * @returns a Promise that resolves to an object of type ResponseSuccessSingleInterface. This object
-   * contains the result of a delete operation performed by the baseService, along with a success
-   * message obtained from the baseMessageService.
-   */
-  async baseDelete(id: string): Promise<ResponseSuccessSingleInterface> {
-    const result: DeleteResult = await this.baseService.delete(id);
-
-    return this.baseResponseService.success(
-      result,
-      this.baseMessageService.get('general.delete.success'),
+      this.messageService.get('general.delete.success'),
     );
   }
 }

--- a/packages/nestjs-base/libs/abstract-base/service/service.base.ts
+++ b/packages/nestjs-base/libs/abstract-base/service/service.base.ts
@@ -75,53 +75,11 @@ export class BaseService<
 
   protected constructor(
     public repository: Repository<EntityDocument>,
-    private readonly baseResponseService: ResponseService,
-    private readonly baseMessageService: MessageService,
-    private readonly className: string,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
+    protected readonly className: string,
   ) {
     this.logger = new Logger(`${className}.${BaseService.name}`);
-  }
-
-  /**
-   * Save an entity in the database. This method can be overridden in child classes.
-   * @param createDTO - The DTO containing the data to be saved
-   * @returns - The saved entity
-   */
-  public async save(createDTO: CreateDTO): Promise<EntityDocument> {
-    return this.baseSave(createDTO);
-  }
-
-  /**
-   * Update an entity in the database. This method can be overridden in child classes.
-   * @param updateDTO - The DTO containing the data to be updated
-   * @param id - The id of the entity to be updated
-   * @returns - The updated entity
-   */
-  public async update(
-    updateDTO: UpdateDTO,
-    id: string,
-  ): Promise<EntityDocument> {
-    return this.baseUpdate(updateDTO, id);
-  }
-
-  /**
-   * Delete an entity from the database. This method can be overridden in child classes.
-   * @param id - The id of the entity to be deleted
-   * @returns - Result of the delete operation
-   */
-  public async delete(id: string): Promise<DeleteResult> {
-    return this.baseDelete(id);
-  }
-
-  /**
-   * Find all entities in the database. This method can be overridden in child classes.
-   * @param mainPagingDTO - The DTO containing pagination data
-   * @returns - The list of entities and pagination details
-   */
-  async findAll(
-    mainPagingDTO: PagingDTO,
-  ): Promise<ListPaginationInterface<EntityDocument>> {
-    return this.baseFindAll(mainPagingDTO);
   }
 
   /**
@@ -129,13 +87,13 @@ export class BaseService<
    * @param createDTO - The DTO containing the data to be saved
    * @returns - The saved entity
    */
-  public async baseSave(createDTO: CreateDTO): Promise<EntityDocument> {
+  public async save(createDTO: CreateDTO): Promise<EntityDocument> {
     try {
       const entitySave: Partial<EntityDocument> = Object.assign({}, createDTO);
       return this.repository.save(entitySave as EntityDocument);
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -145,7 +103,7 @@ export class BaseService<
    * @param id - The id of the entity to be updated
    * @returns - The updated entity
    */
-  public async baseUpdate(
+  public async update(
     updateDTO: UpdateDTO,
     id: string,
   ): Promise<EntityDocument> {
@@ -159,7 +117,7 @@ export class BaseService<
       return this.repository.save(record);
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -168,7 +126,7 @@ export class BaseService<
    * @param id - The id of the entity to be deleted
    * @returns - Result of the delete operation
    */
-  public async baseDelete(id: string): Promise<DeleteResult> {
+  public async delete(id: string): Promise<DeleteResult> {
     try {
       const entity = await this.getAndValidateById(id);
       await this.repository.softRemove(entity);
@@ -179,7 +137,7 @@ export class BaseService<
       } as any;
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -188,10 +146,10 @@ export class BaseService<
    * @param mainPagingDTO - The DTO containing pagination data
    * @returns - The list of entities and pagination details
    */
-  async baseFindAll(
+  async findAll(
     mainPagingDTO: PagingDTO,
   ): Promise<ListPaginationInterface<EntityDocument>> {
-    const query = await this.baseFindAllQuery(mainPagingDTO);
+    const query = await this.findAllQuery(mainPagingDTO);
     try {
       const result = await query.getManyAndCount();
 
@@ -206,7 +164,7 @@ export class BaseService<
       };
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -216,7 +174,7 @@ export class BaseService<
    * @param filterQuery - item that's need to be filtered
    * @param queryBuilder - query builder
    */
-  baseFilterQuery(
+  filterQuery(
     mainPagingDTO: PagingDTO,
     filterQuery: BaseFilterInterfaceSingle<PagingDTO>,
     queryBuilder: SelectQueryBuilder<EntityDocument> | WhereExpressionBuilder,
@@ -260,7 +218,7 @@ export class BaseService<
    * @param filterQueries - items that's need to be filtered
    * @param queryBuilder - query builder
    */
-  baseFilterAllQuery(
+  filterAllQuery(
     mainPagingDTO: PagingDTO,
     filterQueries: BaseFilterInterface<PagingDTO>[],
     queryBuilder: SelectQueryBuilder<EntityDocument> | WhereExpressionBuilder,
@@ -269,11 +227,11 @@ export class BaseService<
       if (Array.isArray(filterQuery)) {
         queryBuilder.andWhere(
           new Brackets((qb) => {
-            this.baseFilterAllQuery(mainPagingDTO, filterQuery, qb);
+            this.filterAllQuery(mainPagingDTO, filterQuery, qb);
           }),
         );
       } else {
-        this.baseFilterQuery(mainPagingDTO, filterQuery, queryBuilder);
+        this.filterQuery(mainPagingDTO, filterQuery, queryBuilder);
       }
     }
   }
@@ -283,7 +241,7 @@ export class BaseService<
    * @param mainPagingDTO - The DTO containing pagination data
    * @returns - The list of entities and pagination details
    */
-  async baseFindAllQuery(
+  async findAllQuery(
     mainPagingDTO: PagingDTO,
   ): Promise<SelectQueryBuilder<EntityDocument>> {
     try {
@@ -300,7 +258,7 @@ export class BaseService<
           }),
         );
       }
-      this.baseFilterAllQuery(mainPagingDTO, this.filterByFields, query);
+      this.filterAllQuery(mainPagingDTO, this.filterByFields, query);
       if (mainPagingDTO.order && mainPagingDTO.sort) {
         let prefix = '';
         if (!mainPagingDTO.sort.includes('.')) {
@@ -316,7 +274,7 @@ export class BaseService<
       return query;
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -333,11 +291,11 @@ export class BaseService<
     mainPagingDTO: PagingDTO,
     relations?: string[],
   ): Promise<ListPaginationInterface<EntityDocument>> {
-    const query = await this.baseFindDetailAllQuery(mainPagingDTO, relations);
-    return this.baseGetManyAndCount(mainPagingDTO, query);
+    const query = await this.findDetailAllQuery(mainPagingDTO, relations);
+    return this.getManyAndCount(mainPagingDTO, query);
   }
 
-  async baseGetManyAndCount(
+  async getManyAndCount(
     mainPagingDTO: PagingDTO,
     query: SelectQueryBuilder<EntityDocument>,
   ) {
@@ -355,7 +313,7 @@ export class BaseService<
       };
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -364,7 +322,7 @@ export class BaseService<
    * @param queryBuilder - query builder
    * @param {PagingDTO} mainPagingDTO - The mainPagingDTO parameter is an object that contains
    */
-  baseSearchAllQuery(
+  searchAllQuery(
     queryBuilder: SelectQueryBuilder<EntityDocument>,
     mainPagingDTO: PagingDTO,
   ) {
@@ -392,7 +350,7 @@ export class BaseService<
    * @param queryBuilder - query builder
    * @param {string[]} relations - optional parameter to override `this.relations`
    */
-  baseAddJoinQuery(
+  addJoinQuery(
     queryBuilder: SelectQueryBuilder<EntityDocument>,
     relations?: string[],
   ) {
@@ -425,16 +383,16 @@ export class BaseService<
    * and "pagination". The "content" property is an array of EntityDocument objects, while the
    * "pagination" property is an object with three properties: "page", "total", and "size".
    */
-  baseFindDetailAllQuery(
+  findDetailAllQuery(
     mainPagingDTO: PagingDTO,
     relations?: string[],
   ): SelectQueryBuilder<EntityDocument> {
     try {
       const query = this.repository.createQueryBuilder(this.tableAlias);
-      this.baseAddJoinQuery(query, relations);
+      this.addJoinQuery(query, relations);
 
-      this.baseSearchAllQuery(query, mainPagingDTO);
-      this.baseFilterAllQuery(mainPagingDTO, this.filterByFields, query);
+      this.searchAllQuery(query, mainPagingDTO);
+      this.filterAllQuery(mainPagingDTO, this.filterByFields, query);
       if (mainPagingDTO.order && mainPagingDTO.sort) {
         let prefix = '';
         if (!mainPagingDTO.sort.includes('.')) {
@@ -453,7 +411,7 @@ export class BaseService<
       return query;
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -470,10 +428,10 @@ export class BaseService<
         .getOne();
       if (!recordEntityDocument) {
         throw new BadRequestException(
-          this.baseResponseService.error(
+          this.responseService.error(
             HttpStatus.BAD_REQUEST,
             [
-              this.baseMessageService.getErrorMessage(
+              this.messageService.getErrorMessage(
                 `${this.tableAlias}_id`,
                 'general.general.id_not_found',
               ),
@@ -485,7 +443,7 @@ export class BaseService<
       return recordEntityDocument;
     } catch (error: any) {
       Logger.error(error.message, '', this.constructor.name);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -508,10 +466,10 @@ export class BaseService<
         .getOne();
       if (!recordEntityDocument) {
         throw new BadRequestException(
-          this.baseResponseService.error(
+          this.responseService.error(
             HttpStatus.BAD_REQUEST,
             [
-              this.baseMessageService.getErrorMessage(
+              this.messageService.getErrorMessage(
                 field,
                 'general.general.data_not_found',
               ),
@@ -523,7 +481,7 @@ export class BaseService<
       return recordEntityDocument;
     } catch (error: any) {
       Logger.error(error.message, '', this.constructor.name);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -555,10 +513,10 @@ export class BaseService<
 
   throwGenericNotFound() {
     throw new BadRequestException(
-      this.baseResponseService.error(
+      this.responseService.error(
         HttpStatus.BAD_REQUEST,
         [
-          this.baseMessageService.getErrorMessage(
+          this.messageService.getErrorMessage(
             'id',
             'general.general.id_not_found',
           ),
@@ -585,7 +543,7 @@ export class BaseService<
       return recordEntityDocument;
     } catch (error: any) {
       this.logger.error(error.message);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 
@@ -614,10 +572,10 @@ export class BaseService<
       const recordEntityDocument = await query.getOne();
       if (recordEntityDocument) {
         throw new BadRequestException(
-          this.baseResponseService.error(
+          this.responseService.error(
             HttpStatus.BAD_REQUEST,
             [
-              this.baseMessageService.getErrorMessage(
+              this.messageService.getErrorMessage(
                 field,
                 `general.general.${field}_exist`,
               ),
@@ -628,7 +586,7 @@ export class BaseService<
       }
     } catch (error: any) {
       Logger.error(error.message, '', this.constructor.name);
-      this.baseResponseService.throwError(error);
+      this.responseService.throwError(error);
     }
   }
 }

--- a/packages/nestjs-replication-data/libs/replication-data/admins-users/admins-users.service.ts
+++ b/packages/nestjs-replication-data/libs/replication-data/admins-users/admins-users.service.ts
@@ -19,8 +19,8 @@ export class AdminsUsersService extends BaseService<
     @InjectRepository(AdminsUserDocument)
     private readonly adminUserRepository: Repository<AdminsUserDocument>,
     private readonly authPermissionService: AuthPermissionsService,
-    private readonly responseService: ResponseService,
-    private readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
   ) {
     super(
       adminUserRepository,
@@ -44,7 +44,7 @@ export class AdminsUsersService extends BaseService<
     if (savePermission) {
       await this.authPermissionService.save(savePermission);
     }
-    return this.baseSave(createDTO);
+    return super.save(createDTO);
   }
 
   async getAndValidateByIds(ids: string[]): Promise<AdminsUserDocument[]> {

--- a/packages/nestjs-replication-data/libs/replication-data/permissions/auth-permissions.service.ts
+++ b/packages/nestjs-replication-data/libs/replication-data/permissions/auth-permissions.service.ts
@@ -18,8 +18,8 @@ export class AuthPermissionsService {
   constructor(
     @InjectRepository(PermissionDocument)
     private readonly permissionRepository: Repository<PermissionDocument>,
-    private readonly messageService: MessageService,
-    private readonly responseService: ResponseService,
+    protected readonly messageService: MessageService,
+    protected readonly responseService: ResponseService,
   ) {}
 
   async save(


### PR DESCRIPTION
BREAKING CHANGE: every calls to `this.base*` from base classes should be changed with `super.*`, for example `this.baseSave` to `super.save`. All private constructor of messageService and responseService should be protected, example: `protected readonly responseService`